### PR TITLE
Changed ifelse structure into a simple return statement (sonarcloud kotlin:S1125)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/CoronaTestRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/CoronaTestRepository.kt
@@ -125,7 +125,7 @@ class CoronaTestRepository @Inject constructor(
 
         val toRefresh = internalData.data
             .first().values
-            .filter { if (type == null) true else it.type == type }
+            .filter { type == null || it.type == type }
             .map { it.identifier }
 
         Timber.tag(TAG).d("Will refresh %s", toRefresh)
@@ -138,7 +138,7 @@ class CoronaTestRepository @Inject constructor(
 
         val refreshedData = internalData.updateBlocking {
             val polling = values
-                .filter { if (type == null) true else it.type == type }
+                .filter { type == null || it.type == type }
                 .filter { toRefresh.contains(it.identifier) }
                 .map { coronaTest ->
 


### PR DESCRIPTION
### Description
I noticed two code smells which can be found here:
https://sonarcloud.io/project/issues?id=corona-warn-app_cwa-app-android&resolved=false&rules=kotlin%3AS1125&types=CODE_SMELL

This pull request simply proposes a small change to `CoronaTestRepository.kt`.
The two `filter { }` calls in question use a redundant `if/else` structure for what can easily be compressed into a single return-statement to improve readability.
(For more detailed references, see: `kotlin:S1125` on sonarcloud)

This also clears 10 minutes of technical debt from the currently accumulated 1 hour of debt on the project.
It's an extremely small change but I thought it was fitting for a first-time contribution.

I refrained from opening issues about these in advance since they are technically "open issues" on sonarcloud already. I can open an issue retrospectively though if you want. Otherwise it's not a big deal if this is an undesired change. I simply saw a small thing to fix and wanted to take the opportunity to contribute to this project <3
